### PR TITLE
Log an error, instead of crashing, when Sputnik API is missing

### DIFF
--- a/src/esputnik.erl
+++ b/src/esputnik.erl
@@ -41,14 +41,13 @@ change_api_url(SputnikApiUrl) ->
 
 %% Gen Server callbacks
 init([]) ->
-    Server = 
-        case esputnik_app:config(sputnik_api_url, undefined) of
-            undefined ->
-                error_logger:info_msg("at=init warning=no_api_set");
-            Url ->
-                Url
-        end,
-    {ok, #state{server=Server}}.
+    case esputnik_app:config(sputnik_api_url, undefined) of
+        undefined ->
+            error_logger:info_msg("at=init warning=no_api_set"),
+            {stop, no_api_set};
+        Url ->
+            {ok, #state{server=Url}}
+    end.
 
 handle_call({change_api_url, SputnikServer}, _From, #state{connection=Connection,
                                                            server=OldSputnikServer}) ->

--- a/src/esputnik_sup.erl
+++ b/src/esputnik_sup.erl
@@ -16,4 +16,4 @@ start_link() ->
 %% Supervisor callbacks
 %% ===================================================================
 init([]) ->
-    {ok, {{one_for_one, 5, 10}, [{esputnik, {esputnik, start_link, []}, permanent, 5000, worker, [esputnik]}]}}.
+    {ok, {{one_for_one, 5, 10}, [{esputnik, {esputnik, start_link, []}, transient, 5000, worker, [esputnik]}]}}.

--- a/test/esputnik_first_SUITE.erl
+++ b/test/esputnik_first_SUITE.erl
@@ -46,10 +46,7 @@ init_per_group(normal, Config) ->
     ok = error_logger:add_report_handler(esputnik_event_handler),
     esputnik_app:start(),
     [{server, Server}|Config];
-init_per_group(no_api, Config) ->
-    ok = application:unset_env(esputnik, sputnik_api_url),
-    ok = error_logger:add_report_handler(esputnik_event_handler),
-    esputnik_app:start(),
+init_per_group(_, Config) ->
     Config.
 
 end_per_group(normal, Config) ->
@@ -259,9 +256,11 @@ sputnik_server_throttle(Config) ->
     Config.
 
 no_api_set(Config) ->
-    ok = esputnik:alert(alert, <<"team">>, <<"esputnik_server">>),
+    ok = application:unset_env(esputnik, sputnik_api_url),
+    ok = error_logger:add_report_handler(esputnik_event_handler),
+    application:start(esputnik),
     [{_, Msg, _}] = wait_for_event(),
-    <<"at=init warning=no_api_set", _/binary>> = list_to_binary(Msg),
+    "at=init warning=no_api_set" = Msg,
     Config.
 
 % Internal


### PR DESCRIPTION
Esputnik has to be started temporarily today as it crashes when the config is missing. This commit changes that behaviour, and  instead of crashing it will log an error for every message it cannot send.

These commits also add a test for this behaviour.
