### PR TITLE
Fix crash on closed connection while recv in body

### DIFF
--- a/src/esputnik_api.erl
+++ b/src/esputnik_api.erl
@@ -123,9 +123,13 @@ http_post(SputnikClient, Endpoint, FormData, _) ->
     end.
 
 http_handle({ok, 200, _, Client}) ->
-    {ok, Body} = hackney:body(Client),
-    Json = jsx:json_to_term(Body),
-    {ok, proplists:get_value(<<"request_id">>, Json), Client};
+    case hackney:body(Client) of
+        {ok, Body} ->
+            Json = jsx:json_to_term(Body),
+            {ok, proplists:get_value(<<"request_id">>, Json), Client};
+        {error, Reason} ->
+            {error, {body, Reason}}
+    end;
 http_handle({ok, 500, _, Client}) ->
     {error, internal_error, Client};
 http_handle({ok, Code, _, Client}) ->


### PR DESCRIPTION
Hackney may discover the connection has been closed while being in the
response body, after which an `{error, {closed, Acc}}` error is
returned:
https://github.com/benoitc/hackney/blob/master/src/hackney_client/hackney_response.erl#L301-L311

This commit makes esputnik expect that possibility and avoid crashing in
a tight loop.
